### PR TITLE
Port番号を指定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 


### PR DESCRIPTION
fastapiのデフォルトは8000番だが、Cloud Runは8080番であることが原因で動かないかもしれない。